### PR TITLE
Add GitHub Actions workflow for publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16' # Setting this to 16 as typescript is 3.9 and react is 16, which is fairly old. It can be updated if needed.
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run linting
+        run: npm run eslint
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "diagnostics": true,
     "listEmittedFiles": true,
     "lib": ["es5", "es6", "dom"],
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules", "build", "scripts", "acceptance-tests", "webpack", "jest", "src/setupTests.ts", "example", "lib", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
Added a GitHub Actions workflow to allow manual publishing to npm, ensuring linting and testing are run before publication. Updated `tsconfig.json` to include `"skipLibCheck": true` to fix compilation issues.

---
*PR created automatically by Jules for task [3079824595295135866](https://jules.google.com/task/3079824595295135866) started by @johnstrand*